### PR TITLE
platform version defined

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -9,7 +9,7 @@
 ; http://docs.platformio.org/page/projectconf.html
 
 [env:senseo-wifi]
-platform = espressif8266
+platform = espressif8266@2.0.4
 board = d1_mini
 framework = arduino
 build_flags = -D PIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY


### PR DESCRIPTION
Hi,

there seems to be [problems with newer version of arduino core](https://github.com/esp8266/Arduino/issues/6127). 
My D1 Mini would crash at boot with a `ISR not in IRAM` error. 

This PR ist the [quick fix](https://github.com/esp8266/Arduino/issues/6127), [this is the longer (and better?) fix](https://github.com/esp8266/Arduino/issues/6127#issuecomment-497785103) I guess.

Best regards
Sören